### PR TITLE
edit title to include abbreviation DFT

### DIFF
--- a/Density-Functional-Theory-for-Molecules.md
+++ b/Density-Functional-Theory-for-Molecules.md
@@ -1,6 +1,6 @@
 
 
-# Density Functional Theory
+# Density Functional Theory (DFT)
 
 The NWChem density functional theory (DFT) module uses the Gaussian
 basis set approach to compute closed shell and open shell densities and


### PR DESCRIPTION
Including DFT in the title will improve search results in pages search feature.