### PR TITLE
Add documentation for i-PI socket communication

### DIFF
--- a/Geometry-Optimization.md
+++ b/Geometry-Optimization.md
@@ -38,6 +38,7 @@ directive,
       PRINT ... 
    XYZ <string xyz default *file_prefix*>]  
    NOXYZ  
+   SOCKET (UNIX || IPI_CLIENT) <string socketname default (see input description)>  
  END
 ```
 On each optimization step a line search is performed. To speed up
@@ -210,6 +211,31 @@ permanent directory.
 
 The script rasmolmovie in the NWChem contrib directory can be used to
 turn these into an animated GIF movie.
+
+
+## i-PI Socket communication
+```
+   SOCKET (UNIX || IPI_CLIENT) <string socketname default (see input description)>  
+```
+The SOCKET directive enables NWChem to communicate with other software
+packages -- such as [i-PI](http://ipi-code.org/) or
+[ASE](https://wiki.fysik.dtu.dk/ase/dev/ase/calculators/socketio/socketio.html) --
+via the i-PI socket protocol.
+
+Communication is done either over Unix sockets (`SOCKET UNIX`) or IP
+sockets (`SOCKET IPI_CLIENT`):
+
+  - Unix sockets - NWChem will create and bind to a UNIX socket
+    file located at `/tmp/ipi_<socketname>`. If not specified,
+    `<socketname>` will default to `nwchem`.
+  - IP sockets - NWChem will bind to the IP address and port
+    specified by `<socketname>`. If not specified, `<socketname>`
+    will default to `127.0.0.1:31415`.
+
+The `SOCKET` directive is only useful when used in conjunction with other
+software packages that support communication via the i-PI socket
+protocol. For more information, see the
+[i-PI documentation](http://ipi-code.org/resources/documentation/).
 
 ## Print options
 

--- a/Plane-Wave-Density-Functional-Theory.md
+++ b/Plane-Wave-Density-Functional-Theory.md
@@ -1933,7 +1933,7 @@ END
 
 The `NWPW` module provides native communication via the i-PI socket protocol.
 The behavior is identical to the
-[i-PI socket communication](Geometry-Optimization.md#i-pi-socket-communication "wikilink")
+[i-PI socket communication](Geometry-Optimization#i-pi-socket-communication "wikilink")
 provided by the `DRIVER` module.
 The `NWPW` implementation of the `SOCKET` directive is better optimized for
 plane-wave calculations.

--- a/Plane-Wave-Density-Functional-Theory.md
+++ b/Plane-Wave-Density-Functional-Theory.md
@@ -1933,7 +1933,7 @@ END
 
 The `NWPW` module provides native communication via the i-PI socket protocol.
 The behavior is identical to the
-[i-PI socket communication](Geometry-Optimization#i-pi-socket-communication "wikilink")
+[i-PI socket communication](Geometry-Optimization.md#i-pi-socket-communication "wikilink")
 provided by the `DRIVER` module.
 The `NWPW` implementation of the `SOCKET` directive is better optimized for
 plane-wave calculations.

--- a/Plane-Wave-Density-Functional-Theory.md
+++ b/Plane-Wave-Density-Functional-Theory.md
@@ -273,6 +273,8 @@ NWPW 
   BO_ALGORITHM [verlet|| velocity-verlet || leap-frog]
   BO_FAKE_MASS <real bo_fake_mass default 500.0> 
 
+  SOCKET (UNIX || IPI_CLIENT) <string socketname default (see input description)>  
+
   MAPPING <integer mapping default 1>  
   NP_DIMENSIONS <integer npi npj default -1 -1>`  
   CAR-PARRINELLO             ... (see section `[`Car-Parrinello`](#Car-Parrinello "wikilink")`) END 
@@ -1921,6 +1923,20 @@ NWPW
   BO_FAKE_MASS <real bo_fake_mass default 500.0> 
 END
 ```
+
+## i-PI Socket Communication
+```
+NWPW
+   SOCKET (UNIX || IPI_CLIENT) <string socketname default (see input description)>
+END
+```
+
+The `NWPW` module provides native communication via the i-PI socket protocol.
+The behavior is identical to the
+[i-PI socket communication](wiki/Geometry-Optimization#i-pi-socket-communication)
+provided by the `DRIVER` module.
+The `NWPW` implementation of the `SOCKET` directive is better optimized for
+plane-wave calculations.
 
 ## Metropolis Monte-Carlo
 ```

--- a/Plane-Wave-Density-Functional-Theory.md
+++ b/Plane-Wave-Density-Functional-Theory.md
@@ -1933,7 +1933,7 @@ END
 
 The `NWPW` module provides native communication via the i-PI socket protocol.
 The behavior is identical to the
-[i-PI socket communication](wiki/Geometry-Optimization#i-pi-socket-communication)
+[i-PI socket communication](Geometry-Optimization#i-pi-socket-communication "wikilink")
 provided by the `DRIVER` module.
 The `NWPW` implementation of the `SOCKET` directive is better optimized for
 plane-wave calculations.

--- a/Plane-Wave-Density-Functional-Theory.md
+++ b/Plane-Wave-Density-Functional-Theory.md
@@ -1938,6 +1938,9 @@ provided by the `DRIVER` module.
 The `NWPW` implementation of the `SOCKET` directive is better optimized for
 plane-wave calculations.
 
+For proper behavior, the `TASK` directive should be set to `GRADIENT`,
+e.g. `TASK PSPW GRADIENT` or `TASK BAND GRADIENT`.
+
 ## Metropolis Monte-Carlo
 ```
 NWPW


### PR DESCRIPTION
Some basic documentation for i-PI socket communication. Explanation of what the i-PI socket communication protocol is/what it is for is outsourced to the i-PI documentation (which is currently broken/gone???? not our problem...).

I tried to create a link between the plane-wave page and the geometry optimization page, but I have no idea whether I've done it correctly. If the link is broken, I would be greatly appreciate if someone with commit access to the nwchem repo would directly edit the wiki to fix this link, since editing the wiki through pull requests is really janky and weird.