### PR TITLE
Add note about CCSDTQ flag

### DIFF
--- a/Compiling-NWChem.md
+++ b/Compiling-NWChem.md
@@ -325,6 +325,12 @@ cluster capability to be included in the code, e.g.
 ```
 export MRCC_METHODS=TRUE
 ```
+
+**CCSDTQ** can be set to request the CCSDTQ method and its derivatives 
+to be included in the code, e.g.
+```
+export CCSDTQ=TRUE
+```
 **Setting Python environment variables**
 
 Python programs may be embedded into the NWChem input and used to


### PR DESCRIPTION
This flag is discussed on the [TCE page](https://github.com/nwchemgit/nwchem-wiki/blob/master/TCE.md) but not in the [adding optional environmental variables section of the compiling page](https://github.com/nwchemgit/nwchem-wiki/blob/master/Compiling-NWChem.md#adding-optional-environmental-variables).