### PR TITLE
Update RT-TDDFT.md

### DIFF
--- a/RT-TDDFT.md
+++ b/RT-TDDFT.md
@@ -359,9 +359,10 @@ end
 
 ```
 field "gpulse"
-  type gaussian   # Gaussian enveloped quasi-monochromatic pulse: E(t) = exp( -(t-t0)^2 / 2s^2)
+  type gaussian   # Gaussian enveloped quasi-monochromatic pulse: E(t) = max * exp( -(t-t0)^2 / 2s^2) * sin(w0*t + phi0)
   polarization x  # = x, y, z
   frequency 0.12  # frequency of laser pulse in au (e.g., 0.12 au = 3.27 eV)
+  phase 0.0       # phase shift of laser pulse (in rad)
   center 200.0    # center of Gaussian envelope (in au time)
   width 50.0      # width of Gaussian pulse (in au time)
   max 0.0001      # maximum value of electric field
@@ -689,7 +690,7 @@ task dft energy
 ## (Gaussian-enveloped) z-polarized E-field tuned to a transition at
 ## 10.25 eV.  The envelope takes the form:
 ##
-## G(t) = exp(-(t-t0)^ / 2s^2)
+## G(t) = exp(-(t-t0)^2 / 2s^2)
 ##
 ## The target excitation has an energy (frequency) of w = 0.3768 au
 ## and thus an oscillation period of T = 2 pi / w = 16.68 au


### PR DESCRIPTION
I added some details to the formula that produces a Gaussian enveloped quasi-monochromatic pulse so that it is exact. Also, the parameter "phase" was missing from the documentation. It's inclusion makes it straightforward to use a narrow Gaussian electric field instead of a delta-type kick field, in order to avoid introducing nonphysical artifacts or instabilities in calculations of absorption spectra, as it is discussed in K. Lopata and N. Govind, J. Chem. Theory Comput. 2011, 7, 5, 1344–1355.

There is also a correction of a typo in the description of "Resonant ultraviolet excitation of water".