### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -16,6 +16,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: push_false
+        id: push_false
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "push_truefalse=false" >> $GITHUB_ENV
+      - name: push_true
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          echo "push_truefalse=true" >> $GITHUB_ENV
       - name: Checkout nwchem-wiki
         uses: actions/checkout@v6
         with:
@@ -32,6 +41,7 @@ jobs:
           git fetch upstream
           git merge upstream/master --no-edit
       - name: Push changes
+        if: ${{ env.push_truefalse == 'true' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,6 +71,7 @@ jobs:
           git fetch upstream
           git merge upstream/master --no-edit
       - name: Push changes
+        if: ${{ env.push_truefalse == 'true' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.REPOSITORY_TOKEN }}
@@ -179,6 +190,7 @@ jobs:
             ls -lrt ../
             bash ../commit_changes.sh
       - name: Push changes
+        if: ${{ env.push_truefalse == 'true' }}
         uses: ad-m/github-push-action@master
         with:
           directory: mkdocs/nwchemgit.github.io

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -13,9 +13,8 @@ jobs:
       github.event_name == 'schedule' ||
       (!contains(github.event.head_commit.message, 'ci skip'))
     runs-on: [ubuntu-22.04]
-#    permissions:
-#      contents: read
-#      pull-requests: write
+    permissions:
+      contents: write
     steps:
       - name: Checkout nwchem-wiki
         uses: actions/checkout@v6
@@ -42,6 +41,8 @@ jobs:
       github.event_name == 'schedule' ||
       (!contains(github.event.head_commit.message, 'ci skip'))
     needs: mirror_dotwiki2repo
+    permissions:
+      contents: write
     runs-on: [ubuntu-22.04]
     steps:
       - name: Checkout nwchem.wiki
@@ -71,6 +72,8 @@ jobs:
       github.event_name == 'schedule' ||
       (!contains(github.event.head_commit.message, 'ci skip'))
     needs: mirror_repo2dotwiki
+    permissions:
+      contents: write
     runs-on: [ubuntu-22.04]
     steps:
       - name: checkout wiki

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           echo " GITHUB_REF_NAME is $GITHUB_REF_NAME"
           curl -LJ  \
-          https://github.com/nwchemgit/archivedforum/tarball/"$GITHUB_REF_NAME"\
+          https://github.com/nwchemgit/archivedforum/tarball/master \
            | tar -xz --wildcards \
           nwchemgit-archivedforum-*/Special_AWCforum/*
           mv nwchemgit-archivedforum-* archivedforum

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -168,12 +168,14 @@ jobs:
           print_page.html nwchemusermanual.pdf
           ls -l nwchemusermanual.pdf
       - name: checkout website
+        if: ${{ env.push_truefalse == 'true' }}
         shell: bash
         working-directory: mkdocs
         run: |
           git clone -b $GITHUB_REF_NAME --depth 1 \
           https://github.com/nwchemgit/nwchemgit.github.io
       - name: update nwchemgit.github.io with new content
+        if: ${{ env.push_truefalse == 'true' }}
         shell: bash
         working-directory: mkdocs
         run: |
@@ -183,6 +185,7 @@ jobs:
           cd nwchemgit.github.io
           time -p git log -1
       - name: Commit changes
+        if: ${{ env.push_truefalse == 'true' }}
         shell: bash
         working-directory: mkdocs/nwchemgit.github.io
         run: |
@@ -198,6 +201,7 @@ jobs:
           branch: ${{ github.ref }}
           repository: nwchemgit/nwchemgit.github.io
       - name: Check commit result
+        if: ${{ env.push_truefalse == 'true' }}
         shell: bash
         working-directory: mkdocs/nwchemgit.github.io
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/nwchemgit/nwchem-wiki/security/code-scanning/3](https://github.com/nwchemgit/nwchem-wiki/security/code-scanning/3)

In general, the problem is fixed by defining an explicit `permissions` block that limits what the automatically generated `GITHUB_TOKEN` can do. This can be done at the workflow level (applies to all jobs) or per job. Since all three jobs perform Git operations and at least some use `GITHUB_TOKEN` for pushing, they all legitimately require `contents: write` but likely no other scopes. We should therefore set `permissions: contents: write` for each job (or once at the top for the whole workflow).

The minimal, functionality-preserving change is:
- Add a workflow-level `permissions` block after the `name:` and `on:` sections, or,
- Since we must only touch shown lines, add a `permissions` block under each job definition (`mirror_dotwiki2repo`, `mirror_repo2dotwiki`, and `NWChem_website_update`), at the same indentation as `runs-on:`.

Because the jobs push commits to repositories, they need `contents: write` rather than `contents: read`. No extra imports or dependencies are required; this is purely a YAML configuration change within `.github/workflows/github_actions.yml`.

Concretely:
- For `mirror_dotwiki2repo`, replace the old commented-out permissions block with an active one providing `contents: write`.
- For `mirror_repo2dotwiki`, add `permissions: contents: write` between `needs:` and `runs-on:`.
- For `NWChem_website_update`, add `permissions: contents: write` between `needs:` and `runs-on:` (near line 70 where CodeQL flagged the issue).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
